### PR TITLE
FIX #51: Use mastodon.social for Account Lookup

### DIFF
--- a/server/src/api/lookup/lookup-handler.js
+++ b/server/src/api/lookup/lookup-handler.js
@@ -26,9 +26,9 @@ export default async function accountLookupHandler(req, res) {
         });
     }
 
-    const { username, server } = account;
+    const { username } = account;
     try {
-        const api = FediverseAPIFactory.createAdapter(server);
+        const api = FediverseAPIFactory.createAdapter();
         const accountInfo = await accountLookupService(api, acct);
         if (accountInfo) {
             res.json(accountInfo);


### PR DESCRIPTION
We were using the original server for account lookup but for all other services we are always using mastodon.social. This creates inconsistency because the user id is unique on each server.